### PR TITLE
Add instructions to enable GitHub Actions when forking the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Setup database with:
    rails db:migrate
 ```
 
+### Github Actions
+
+To make sure the linters' checks using Github Actions work properly, you should follow the next steps:
+
+1. On your recently forked repo, enable the GitHub Actions in the Actions tab.
+2. Create the `feature/branch` and push.
+3. Start working on your milestone as usual.
+4. Open a PR from the `feature/branch` when your work is done.
 
 
 ### Usage


### PR DESCRIPTION
The purpose of the Pull Request is to avoid a problem that some students are experiencing when creating a PR and not being able to see GitHub Actions perform the linters' checks.

The changes applied to the README include the instructions on how to configure GitHub Actions when the students fork the repo to avoid the above issue and ensure the correct workflow.

